### PR TITLE
Refined button event trigger

### DIFF
--- a/pcg850vs_gadget_1/pcg850vs_gadget_1.ino
+++ b/pcg850vs_gadget_1/pcg850vs_gadget_1.ino
@@ -1450,8 +1450,8 @@ void update_buttons()
 	    }
 	}
       
-      // If button has gone from pressed to not pressed then we treat that as a key event
-      if( (buttons[i].last_pressed == true) && (buttons[i].pressed == false) )
+      // If button has gone from not pressed to pressed then we treat that as a key event
+      if( (buttons[i].last_pressed == false) && (buttons[i].pressed == true) )
 	{
 	  Serial.println("Call ev");
 	  (buttons[i].event_fn)();


### PR DESCRIPTION
It feels more natural when the button event is emitted and acted upon when the button is pressed as opposed to released after being pressed. It's in line with the computer keyboard behaviour, remote controls, game pads, etc. What do you think?
