### PR TITLE
Added @file annotation to specify the file name

### DIFF
--- a/pcg850vs_gadget_1/pcg850vs_gadget_1.ino
+++ b/pcg850vs_gadget_1/pcg850vs_gadget_1.ino
@@ -576,6 +576,10 @@ void cmd_initsd(String cmd)
 
 }
 
+// Tests if the the specified tag matches the bytes at the specified position of
+// a 0x1A-terminated segment at the specified position of the buffer.
+// Please note that len is the buffer size (from position zero) and not the segment.
+
 static inline bool matches(const char *s, size_t len, int pos, const char *tag,
         size_t taglen)
 {
@@ -584,15 +588,23 @@ static inline bool matches(const char *s, size_t len, int pos, const char *tag,
     return i == taglen;
 }
 
+// Returns the index of the first occurence of the tag in the specified buffer
+// or -1 if the tag has not been found.
+
 static int index_of(const char *s, size_t len, const char *tag, size_t taglen)
 {
     int i;
-    for (i = 0; i < len && s[i] != 0x1A; i++) {
+    for (i = 0; i < len && s[i] != 0x1A; i++)
+      {
         if (matches(s, len, i, tag, taglen))
             return i;
-    }
+      }
     return -1;
 }
+
+// Retrieves the file name from the respective annotation tag stored in the 0x1A
+// terminated segment of the specified buffer.
+// Returns true if the file name is successfully retrieved, false otherwise.
 
 static bool get_filename(const char *s, size_t len, char *dst, size_t dstlen)
 {

--- a/pcg850vs_gadget_1/pcg850vs_gadget_1.ino
+++ b/pcg850vs_gadget_1/pcg850vs_gadget_1.ino
@@ -1450,8 +1450,8 @@ void update_buttons()
 	    }
 	}
       
-      // If button has gone from pressed to not pressed then we treat that as a key event
-      if( (buttons[i].last_pressed == true) && (buttons[i].pressed == false) )
+      // If button has gone from not pressed to pressed then we treat that as a key event
+      if( (buttons[i].last_pressed == false) && (buttons[i].pressed == true) )
 	{
 	  Serial.println("Call ev");
 	  (buttons[i].event_fn)();


### PR DESCRIPTION
This enhancement makes it possible to specify the file name (overriding the one generated by the Gadget) in the body of a PC-G850VS program (irrespective of the language being used) by using the `@file <filename.ext>` annotation.

The annotation can be used anywhere in the source code. Any subsequent occurrence of the same annotation in the same file is ignored.

Here is a sample BASIC program using the annotation:

```
10 REM @file hello.bas
20 PRINT "Hello, world!"
```

If the annotation is not specified in the file being written to the SD card, the default file naming convention is used.

Custom utility functions were used to support the 0x1A EOF terminator.