### PR TITLE
Fixed the buffer offset issue after SIO made active

### DIFF
--- a/pcg850vs_gadget_1/pcg850vs_gadget_1.ino
+++ b/pcg850vs_gadget_1/pcg850vs_gadget_1.ino
@@ -414,7 +414,8 @@ void cmd_display(String cmd)
 
 void cmd_clear(String cmd)
 {
-  bytecount = -1;    // We reset to -1 so we drop the leading spurious character
+  if (bytecount)
+    bytecount = -1;    // We reset to -1 so we drop the leading spurious character
 
 #if DIRECT_WRITE
   SD.remove(filename);
@@ -883,7 +884,8 @@ void button_scope_if(MENU_ELEMENT *e)
 
 void button_clear(MENU_ELEMENT *e)
 {
-  bytecount = -1;
+  if (bytecount)
+    bytecount = -1;
 
   display.clearDisplay();
   display.setCursor(0,0);


### PR DESCRIPTION
This change addresses the problem with the first missing character when the clear buffer command or button event are initiated before the first file is received from the Pocket PC but after the SIO mode is initialised.

The change gives a special meaning to the zero `bytecount` value and prevents the clear buffer routine from pulling the index back to -1 immediately after the SIO mode activation.
